### PR TITLE
fix: correct link to vacancies page (on team members site)

### DIFF
--- a/_data/team_members.yml
+++ b/_data/team_members.yml
@@ -198,7 +198,7 @@
            
 - name: "This could be you !"
   photo: smile.png
-  info: See <a href="http://schuetze.cis.lmu.de/vacancies/">openings</a> for more info
+  info: See <a href="/vacancies">openings</a> for more info
   email: schuetze_lab@cis.lmu.de
   number_educ: 0
   education1:


### PR DESCRIPTION
Hi guys,

this PR fixes the current link to the vacancies page on the team member site.

The original reference `http://schuetze.cis.lmu.de/vacancies/` provides indeed a redict, but it is leading to a 404 because of a missing slash:

```bash
$ curl  http://schuetze.cis.lmu.de/vacancies
<p>The document has moved <a href="https://cisnlp.github.iovacancies">here</a>.</p>
```

I used a relative link now to the vacancies page.